### PR TITLE
fix: replace estraverse with eslint keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extension-test-runner",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extension-test-runner",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.19",
         "acorn-loose": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,13 @@
         "data-uri-to-buffer": "^6.0.1",
         "enhanced-resolve": "^5.15.0",
         "error-stack-parser": "^2.1.4",
-        "estraverse": "^5.3.0",
+        "eslint-visitor-keys": "^3.4.3",
         "minimatch": "^9.0.3",
         "split2": "^4.2.0",
         "stacktrace-parser": "^0.1.10"
       },
       "devDependencies": {
         "@types/chai": "^4.3.7",
-        "@types/estraverse": "^5.1.4",
         "@types/estree": "^1.0.2",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.2",
@@ -504,15 +503,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.7.tgz",
       "integrity": "sha512-/k+vesl92vMvMygmQrFe9Aimxi6oQXFUX9mA5HanTrKUSAMoLauSi6PNFOdRw0oeqilaW600GNx2vSaT2f8aIQ==",
       "dev": true
-    },
-    "node_modules/@types/estraverse": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-5.1.4.tgz",
-      "integrity": "sha512-vWk/Pr08mWnzh2ckEqt4JEYCZcjJ1Tb0pJcNs4lRX660NbON2bKPN6busy+8TzUzV0AhLEOHphK8W+KBZtZ8kQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.2",
@@ -1226,12 +1216,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "engines": {
-        "node": ">=4.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Extension Test Runner",
   "description": "Runs tests in VS Code extensions",
   "publisher": "ms-vscode",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.83.0"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.7",
-    "@types/estraverse": "^5.1.4",
     "@types/estree": "^1.0.2",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.2",
@@ -133,7 +132,7 @@
     "data-uri-to-buffer": "^6.0.1",
     "enhanced-resolve": "^5.15.0",
     "error-stack-parser": "^2.1.4",
-    "estraverse": "^5.3.0",
+    "eslint-visitor-keys": "^3.4.3",
     "minimatch": "^9.0.3",
     "split2": "^4.2.0",
     "stacktrace-parser": "^0.1.10"

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 export const enum ItemType {
@@ -46,7 +45,7 @@ export function* getContainingItemsForFile(
       const item = ctrl.createTestItem(
         filePath[i],
         filePath[i],
-        uri.with({ path: filePath.slice(0, i + 1).join(path.sep) }),
+        uri.with({ path: filePath.slice(0, i + 1).join('/') }),
       );
       item.tags = createOpts.tags;
       testMetadata.set(


### PR DESCRIPTION
Fixes parsing failing in copilot due to a lack of static blocks (https://github.com/estools/estraverse/pull/120)