### PR TITLE
fix: show errors in an editor instead of modal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
   "typescript.tsc.autoDetect": "off",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extension-test-runner",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extension-test-runner",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.19",
         "acorn-loose": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Extension Test Runner",
   "description": "Runs tests in VS Code extensions",
   "publisher": "ms-vscode",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.83.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,13 +66,18 @@ export function activate(context: vscode.ExtensionContext) {
     }
   };
 
+  const openUntitledEditor = async (contents: string) => {
+    const untitledDoc = await vscode.workspace.openTextDocument({ content: contents });
+    await vscode.window.showTextDocument(untitledDoc);
+  };
+
   const showConfigError = async (configUriStr: string) => {
     const configUri = vscode.Uri.parse(configUriStr);
     const ctrl = ctrls.find((c) => c.configFile.uri.toString() === configUri.toString());
     try {
       await ctrl?.configFile.read();
     } catch (e) {
-      vscode.window.showErrorMessage(String(e), { modal: true });
+      await openUntitledEditor(String(e));
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/200862