### PR TITLE
fix: evaluation extraction with constructors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "vscode": "^1.88.0"
+        "vscode": "^1.88.0-insider"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/src/extract/evaluate.test.ts
+++ b/src/extract/evaluate.test.ts
@@ -174,4 +174,19 @@ describe('evaluate', () => {
       },
     ]);
   });
+
+  it('does not break on constructors', () => {
+    const src = extractWithEvaluation(`new foo.Bar(); it('works', () => {});`, defaultTestSymbols);
+    expect(src).to.deep.equal([
+      {
+        name: 'works',
+        kind: NodeKind.Test,
+        startLine: 1,
+        startColumn: 16,
+        endLine: 1,
+        endColumn: Number.MAX_SAFE_INTEGER,
+        children: [],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Stumbled upon the solution in another project a bit ago, this fixes a
case where evaluation extraction for tests had been bailing out. It now
never bails out in extension tests in the vscode repo.