### PR TITLE
Specify folder name to distinguish it if/when the VS Code workspace has more than one VS Code extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
               ? folders.length > 1
                 ? `Extension (${folder.name}: ${rel})`
                 : `Extension (${rel})`
-              : 'VS Code Extension',
+              : 'VS Code Extension (${folder.name})',
           );
 
           ctrls.push(new Controller(ctrl, folder, smStore, file, runner, wrapperCfg));


### PR DESCRIPTION
Specify folder name to distinguish it if/when the VS Code workspace has more than one VS Code extension