### PR TITLE
fix: use acorn (strict) before acorn-loose in syntax extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
+        "acorn": "^8.15.0",
         "acorn-loose": "^8.5.2",
         "ansi-colors": "^4.1.3",
         "data-uri-to-buffer": "^6.0.2",
@@ -31,7 +32,6 @@
         "@vscode/dts": "^0.4.1",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
-        "acorn": "^8.15.0",
         "chai": "^6.2.1",
         "esbuild": "^0.27.1",
         "glob": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "@vscode/dts": "^0.4.1",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
-    "acorn": "^8.15.0",
     "chai": "^6.2.1",
     "esbuild": "^0.27.1",
     "glob": "^13.0.0",
@@ -145,6 +144,7 @@
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.31",
+    "acorn": "^8.15.0",
     "acorn-loose": "^8.5.2",
     "ansi-colors": "^4.1.3",
     "data-uri-to-buffer": "^6.0.2",

--- a/src/extract/syntax.test.ts
+++ b/src/extract/syntax.test.ts
@@ -87,4 +87,42 @@ describe('syntax', () => {
     );
     expect(src).to.deep.equal([]);
   });
+
+  it('handles inconsistent indentation without misplacing nodes', () => {
+    // acorn-loose uses indentation heuristics that can misplace block
+    // boundaries when a line has extra indentation followed by a dedent.
+    // With the acorn-strict-first approach, well-formed JS is parsed
+    // correctly regardless of indentation.
+    const src = extractWithAst(
+      [
+        "suite('Root', function () {",
+        "    suite('A', function () {",
+        "        test('A1', function () {",
+        '            if (true) {',
+        '                    x();', // ← extra indent (20 spaces)
+        '                y();', // ← normal indent (16 spaces)
+        '            }',
+        '        });',
+        "        test('A2', function () {});",
+        '    });',
+        "    suite('B', function () {",
+        "        test('B1', function () {});",
+        '    });',
+        '});',
+      ].join('\n'),
+      defaultTestSymbols,
+    );
+
+    // Should produce a single root suite with two child suites
+    expect(src).to.have.length(1);
+    expect(src[0].name).to.equal('Root');
+    expect(src[0].children).to.have.length(2);
+    expect(src[0].children[0].name).to.equal('A');
+    expect(src[0].children[0].children).to.have.length(2);
+    expect(src[0].children[0].children[0].name).to.equal('A1');
+    expect(src[0].children[0].children[1].name).to.equal('A2');
+    expect(src[0].children[1].name).to.equal('B');
+    expect(src[0].children[1].children).to.have.length(1);
+    expect(src[0].children[1].children[0].name).to.equal('B1');
+  });
 });

--- a/src/extract/syntax.ts
+++ b/src/extract/syntax.ts
@@ -2,8 +2,8 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import type { Options } from 'acorn';
-import { parse } from 'acorn-loose';
+import { parse as strictParse, type Options } from 'acorn';
+import { parse as looseParse } from 'acorn-loose';
 import * as evk from 'eslint-visitor-keys';
 import { Node } from 'estree';
 import { IParsedNode, ITestSymbols, NodeKind } from '../extract';
@@ -57,14 +57,22 @@ const traverse = (
 };
 
 export const extractWithAst = (text: string, symbols: ITestSymbols) => {
-  const ast = parse(text, acornOptions);
+  let ast: Node;
+  try {
+    ast = strictParse(text, acornOptions) as unknown as Node;
+  } catch {
+    // Strict parse failed — fall back to the error-tolerant parser.
+    // Note: acorn-loose uses indentation heuristics that can misplace block
+    // boundaries when indentation is inconsistent.
+    ast = looseParse(text, acornOptions) as unknown as Node;
+  }
 
   const interestingName = (name: string) =>
     symbols.suite.includes(name)
       ? NodeKind.Suite
       : symbols.test.includes(name)
-      ? NodeKind.Test
-      : undefined;
+        ? NodeKind.Test
+        : undefined;
   const stack: { node: Node; r: IParsedNode }[] = [];
   stack.push({ node: undefined, r: { children: [] } } as any);
 


### PR DESCRIPTION
# Extension Test Runner: `extractWith: "syntax"` misparses well-formed JS with inconsistent indentation

## Summary

When `extension-test-runner.extractSettings.extractWith` is set to `"syntax"`, the test extraction produces an **incorrect test tree** for certain well-formed test files. Nested suites/tests get "promoted" to incorrect parent levels, causing the Test Explorer to report tests as **skipped** when they actually pass.

## Root Cause

The `"syntax"` mode uses **`acorn-loose`** (error-tolerant parser), which employs **indentation heuristics** to guess block boundaries. Inconsistent indentation inside test bodies (e.g., extra spaces on a line) causes `acorn-loose` to miscalculate where function bodies end.

Standard `acorn` has no such heuristic and parses the same code correctly.

## Minimal Reproducible Example

```js
suite('Root', function () {
    suite('A', function () {
        test('A1', function () {
            if (true) {
                    x();   // ← 20 spaces (extra indent)
                y();       // ← 16 spaces (normal)
            }
        });
        test('A2', function () {});
    });
    suite('B', function () {
        test('B1', function () {});
    });
});
```

**Expected** (`acorn` or `"evaluation"` mode):
```
[suite] Root
  [suite] A
    [test] A1
    [test] A2
  [suite] B
    [test] B1
```

**Actual** (`acorn-loose` / `"syntax"` mode):
```
[suite] Root
  [suite] A       ← only 1 child instead of 2
    [test] A1
  [test] A2       ← wrongly promoted to Root level
[suite] B         ← wrongly promoted to root level
  [test] B1
```

Fixing the indentation (20→16) or switching to `"evaluation"` mode both resolve the issue.

## Mechanism

`acorn-loose`'s `closes()` method uses `this.curIndent < i` to decide if a block has ended. When a line has extra indentation (20 spaces) followed by a line at normal indentation (16 spaces), the dedent triggers `closes()` to think the function body ended early. This truncates the `test('A1', ...)` CallExpression's end position, causing the AST walker to pop the stack too early and misplace subsequent siblings.

## Proposed Fix

**Try `acorn` (strict parser) first, fall back to `acorn-loose` only on parse failure.**

In `src/extract/syntax.ts`:

```diff
-import type { Options } from 'acorn';
-import { parse } from 'acorn-loose';
+import { parse as strictParse, type Options } from 'acorn';
+import { parse as looseParse } from 'acorn-loose';

 export const extractWithAst = (text: string, symbols: ITestSymbols) => {
-  const ast = parse(text, acornOptions);
+  let ast: Node;
+  try {
+    ast = strictParse(text, acornOptions) as unknown as Node;
+  } catch {
+    // Strict parse failed — fall back to the error-tolerant parser.
+    // Note: acorn-loose uses indentation heuristics that can misplace block
+    // boundaries when indentation is inconsistent.
+    ast = looseParse(text, acornOptions) as unknown as Node;
+  }
```

In `package.json`, move `acorn` from `devDependencies` to `dependencies` (it's already a devDep at `^8.15.0`; esbuild bundles it into the worker).

**Why this works:**
- `acorn` (strict) has no indentation heuristic — it produces correct ASTs for all syntactically valid JS regardless of formatting
- `acorn-loose` is preserved as a fallback for genuinely broken/incomplete code
- This mirrors the existing pattern in `worker.ts` where `evaluation` falls back to `syntax`
- `acorn` is already a dependency (just needs to move from dev to prod); no new dependency
- Bundle size impact is minimal since esbuild tree-shakes and `acorn-loose` already depends on `acorn`

A working implementation with test is available at: `fix/syntax-acorn-strict-first` branch (4 files, +53 lines).

## Workaround

Set `"extractWith": "evaluation"` (the default):

```json
{
    "extension-test-runner.extractSettings": {
        "extractWith": "evaluation"
    }
}
```

## Documentation Improvement

The current description says:

> The `extractWith` mode, that specifies if tests are extracted via evaluation or syntax-tree parsing. Evaluation is likely to lead to better results, but may have side-effects. Defaults to evaluation.

A more helpful description would mention the indentation sensitivity of syntax mode:

> `extractWith`: `"evaluation"` runs test files in a sandboxed VM to discover tests (accurate, but may have side-effects). `"syntax"` parses test files as AST using a lenient parser (no side-effects, but may produce wrong results if indentation is inconsistent - using a code formatter for consistent indentation is recommended). Defaults to `"evaluation"`.

## Environment
- **Extension**: ms-vscode.extension-test-runner v0.0.14
- **VS Code**: 1.99+
- **OS**: Windows 11 (likely affects all platforms)